### PR TITLE
Add include filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This extension contributes the following settings:
 
 * `yamlPathExtractor.pathSeparator`: String used to separate the path parts. For example, 'path **.** to **.** your **.** key' Default is '.' (dot)
 * `yamlPathExtractor.ignoreFilenameRoot`: Ignore the root key if it matches the file name. This is usefull for I18n on Ruby on Rails. Default is `true`
+* `yamlPathExtractor.includeFilename`: Include the yaml file's name as first step in the path.
+Default is `false`
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,15 @@
 						"Ignore the root key if it matches the file name. Example: /en.yml -> en: key: value -> key.value",
 						"Don't ignore the root key if it matches the file name. Example: /en.yml -> en: key: value -> en.key.value"
 					]
+				},
+				"yamlPathExtractor.includeFilename": {
+					"type": "boolean",
+					"default": false,
+					"enum": [
+						true,
+						false
+					],
+					"markdownDescription": "Include the yaml file's name as first step in the path."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -15,24 +15,26 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
-		"configuration":{
+		"configuration": {
 			"title": "Yaml Path Extractor",
 			"properties": {
-				"yamlPathExtractor.pathSeparator":{
+				"yamlPathExtractor.pathSeparator": {
 					"type": "string",
 					"default": ".",
 					"markdownDescription": "String used to separate the path parts. For example, 'path **.** to **.** your **.** key'"
 				},
-				"yamlPathExtractor.ignoreFilenameRoot":{
+				"yamlPathExtractor.ignoreFilenameRoot": {
 					"type": "boolean",
 					"default": true,
-					"enum": [true, false],
+					"enum": [
+						true,
+						false
+					],
 					"markdownDescription": "Ignore the root key if it matches the file name. This is usefull for I18n on Ruby on Rails.",
 					"enumDescriptions": [
 						"Ignore the root key if it matches the file name. Example: /en.yml -> en: key: value -> key.value",
 						"Don't ignore the root key if it matches the file name. Example: /en.yml -> en: key: value -> en.key.value"
 					]
-
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as clipboardy from 'clipboardy';
-import { yamlKeyExtractor } from './yaml_key_extractor';
+import { YamlKeyExtractor } from './yaml_key_extractor';
 export function activate(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand('extension.extractKey', async () => {
 		const editor = vscode.window.activeTextEditor;
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 		const document = editor.document;
 		const position = editor.selection.active;
-		const extractor = new yamlKeyExtractor(document, position);
+		const extractor = new YamlKeyExtractor(document, position);
 		await extractor.extractYamlKey();
 		let fullPath = extractor.fullPath();
 		clipboardy.writeSync(fullPath);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { yamlKeyExtractor } from '../../yaml_key_extractor';
+import { YamlKeyExtractor } from '../../yaml_key_extractor';
 import { Selection, Position } from 'vscode';
 import * as vscode from 'vscode';
 
@@ -8,8 +8,8 @@ suite('Extension Test Suite', async () => {
 	test('Simple test', async () => {
 		const testCoverage = await vscode.workspace.findFiles("**/test1.yml");
 		let document = await vscode.workspace.openTextDocument(testCoverage[0]);
-		let position = new Position(2, 15)
-		let extractor = new yamlKeyExtractor(document, position)
+		let position = new Position(2, 15);
+		let extractor = new YamlKeyExtractor(document, position);
 		await extractor.extractYamlKey();
 		let fullPath = extractor.fullPath();
 		assert.equal(fullPath, 'key1.key12.key121');
@@ -17,8 +17,8 @@ suite('Extension Test Suite', async () => {
 	test('Ignore root test', async () => {
 		const testCoverage = await vscode.workspace.findFiles("**/test2.yml");
 		let document = await vscode.workspace.openTextDocument(testCoverage[0]);
-		let position = new Position(2, 15)
-		let extractor = new yamlKeyExtractor(document, position)
+		let position = new Position(2, 15);
+		let extractor = new YamlKeyExtractor(document, position);
 		await extractor.extractYamlKey();
 		let fullPath = extractor.fullPath();
 		assert.equal(fullPath, 'key12.key121');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -23,4 +23,15 @@ suite('Extension Test Suite', async () => {
 		let fullPath = extractor.fullPath();
 		assert.equal(fullPath, 'key12.key121');
 	});
+	test('Include file name test', async () => {
+		const testCoverage = await vscode.workspace.findFiles("**/test2.yml");
+		vscode.workspace.getConfiguration()
+      .update('yamlPathExtractor.pathSeparator', true);
+		let document = await vscode.workspace.openTextDocument(testCoverage[0]);
+		let position = new Position(2, 15);
+		let extractor = new YamlKeyExtractor(document, position);
+		await extractor.extractYamlKey();
+		let fullPath = extractor.fullPath();
+		assert.equal(fullPath, 'test2.key12.key121');
+	});
 });

--- a/src/yaml_key_extractor.ts
+++ b/src/yaml_key_extractor.ts
@@ -35,6 +35,10 @@ export class YamlKeyExtractor {
   fullPath(): string {
     const separator = vscode.workspace.getConfiguration()
       .get('yamlPathExtractor.pathSeparator') as string;
+    if (vscode.workspace.getConfiguration()
+      .get('yamlPathExtractor.includeFilename')) {
+      this.extractedSymbols.unshift(this.fileName);
+    }
     return this.extractedSymbols.join(separator);
   }
 
@@ -62,8 +66,6 @@ export class YamlKeyExtractor {
       .get('yamlPathExtractor.ignoreFilenameRoot') !== true) {
       return true;
     }
-    let fileName = this.document.fileName;
-    fileName = fileName.substr(fileName.lastIndexOf('/') + 1);
     return this.extractedSymbols.length > 0 ||
       symbol.name !== this.fileName;
   }

--- a/src/yaml_key_extractor.ts
+++ b/src/yaml_key_extractor.ts
@@ -1,7 +1,7 @@
 import { TextDocument, Position } from 'vscode';
 import * as vscode from 'vscode';
 
-export class yamlKeyExtractor {
+export class YamlKeyExtractor {
   private document: TextDocument;
   private position: Position;
   private extractedSymbols: Array<string>;
@@ -26,7 +26,7 @@ export class yamlKeyExtractor {
 
   fullPath(): string {
     const separator = vscode.workspace.getConfiguration()
-      .get('yamlPathExtractor.pathSeparator') as string
+      .get('yamlPathExtractor.pathSeparator') as string;
     return this.extractedSymbols.join(separator);
   }
 
@@ -37,14 +37,14 @@ export class yamlKeyExtractor {
       }
 
       if (this.shouldAddSymbol(symbol)) {
-        this.extractedSymbols.push(symbol.name)
+        this.extractedSymbols.push(symbol.name);
       }
 
       if (!symbol.children) {
         return;
       }
 
-      this.cursorSimbols(symbol.children)
+      this.cursorSimbols(symbol.children);
     }
     return;
   }
@@ -55,7 +55,7 @@ export class yamlKeyExtractor {
       return true;
     }
     let fileName = this.document.fileName;
-    fileName = fileName.substr(fileName.lastIndexOf('/') + 1)
+    fileName = fileName.substr(fileName.lastIndexOf('/') + 1);
     return this.extractedSymbols.length > 0 ||
       symbol.name !== fileName.substr(0, fileName.lastIndexOf('.'));
   }

--- a/src/yaml_key_extractor.ts
+++ b/src/yaml_key_extractor.ts
@@ -5,11 +5,19 @@ export class YamlKeyExtractor {
   private document: TextDocument;
   private position: Position;
   private extractedSymbols: Array<string>;
+  private fileName: string;
 
   constructor(document: TextDocument, position: Position) {
     this.document = document;
     this.position = position;
     this.extractedSymbols = [];
+    this.fileName = this.getFilename();
+  }
+
+  private getFilename() {
+    let fileName = this.document.fileName;
+    fileName = fileName.substr(fileName.lastIndexOf('/') + 1);
+    return fileName.substr(0, fileName.lastIndexOf('.'));
   }
 
   async extractYamlKey(){
@@ -57,6 +65,6 @@ export class YamlKeyExtractor {
     let fileName = this.document.fileName;
     fileName = fileName.substr(fileName.lastIndexOf('/') + 1);
     return this.extractedSymbols.length > 0 ||
-      symbol.name !== fileName.substr(0, fileName.lastIndexOf('.'));
+      symbol.name !== this.fileName;
   }
 }


### PR DESCRIPTION
:wave: Hi thanks for this extension! 

Here is a PR to add a `includeFilename` option to the extension so that the path is prepended with the filename (without extension) when set to `true` (defaults to `false`).

Would you be interested in adding such a feature? If so, please let me know what should be done to make it meet your standards ;)
